### PR TITLE
Handle zero division in metrics calculations

### DIFF
--- a/utils/metrics.py
+++ b/utils/metrics.py
@@ -1,8 +1,15 @@
 from sklearn.metrics import f1_score, accuracy_score, precision_score, recall_score
 
+
 def log_metrics(y_true, y_pred):
+    """Compute classification metrics.
+
+    ``precision_score`` and ``recall_score`` use ``zero_division=0`` to suppress
+    warnings when a class has no predicted or true samples.
+    """
+
     acc = accuracy_score(y_true, y_pred)
     f1 = f1_score(y_true, y_pred)
-    precision = precision_score(y_true, y_pred)
-    recall = recall_score(y_true, y_pred)
+    precision = precision_score(y_true, y_pred, zero_division=0)
+    recall = recall_score(y_true, y_pred, zero_division=0)
     return acc, f1, precision, recall


### PR DESCRIPTION
## Summary
- avoid precision/recall divide-by-zero warnings by setting `zero_division=0`
- document that precision and recall suppress warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890cb67b41083299c34421a123fb2da