### PR TITLE
Add compose support for CPU/GPU Docker workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Version control
+.git
+.gitignore
+
+# Python caches
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.pkl
+
+# Virtual environments
+.env
+.venv
+
+# Build artifacts
+*.so
+*.dll
+*.egg-info
+
+# Data & outputs (optional mounts during runtime)
+results/
+wandb/
+logs/
+data/
+datasets/
+
+# OS/editor files
+.DS_Store
+*.swp

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Virtual environments
+.env
+.venv
+env/
+venv/
+
+# IDEs and editors
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# Logs and debug
+*.log
+logs/
+wandb/
+results/
+
+# Data and checkpoints
+data/
+datasets/
+checkpoints/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Docker
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Base image with Python 3.12 for CPU workloads
+FROM python:3.12-slim
+
+# Prevent Python from writing .pyc files and ensure logs are flushed
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    WANDB_MODE=online
+
+WORKDIR /app
+
+# System dependencies for scientific Python stacks and image utilities
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    git \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
+    libgl1 \
+    libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies first to leverage Docker layer caching
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Default command opens a shell for interactive use (VS Code, Jupyter, bash)
+CMD ["bash"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,42 @@
+# GPU-enabled image with Python 3.12
+FROM nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1 \
+    WANDB_MODE=online
+
+WORKDIR /app
+
+# Install Python 3.12 and common build/image dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    curl \
+    ca-certificates \
+    git \
+    build-essential \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
+    libgl1 \
+    libglib2.0-0 \
+    && add-apt-repository ppa:deadsnakes/ppa \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    python3.12 \
+    python3.12-venv \
+    python3.12-distutils \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.12 \
+    && ln -sf /usr/bin/python3.12 /usr/bin/python \
+    && ln -sf /usr/local/bin/pip /usr/bin/pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip and install Python dependencies
+COPY requirements.txt ./
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir -r requirements.txt
+
+# Copy project files
+COPY . .
+
+# Default command opens a shell for interactive use
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -82,6 +82,58 @@ pip install "cupy-cuda12x"                # CuPy (CUDA 12.x)
 conda install -c pytorch -c nvidia pytorch pytorch-cuda=12.1 -y
 ```
 
+### Docker & Docker Compose (CPU + GPU)
+
+Python **3.12** images are provided for both CPU-only and GPU-capable hosts. W&B logging is forced **online** via `WANDB_MODE=online` in both images.
+
+#### CPU image
+```bash
+docker build -t parallel-programming:cpu -f Dockerfile .
+
+# Start an interactive container (VS Code devcontainers, bash, or Jupyter)
+docker run --rm -it \
+  -p 8888:8888 \
+  -v $(pwd):/app \
+  parallel-programming:cpu
+```
+
+#### GPU image
+```bash
+docker build -t parallel-programming:gpu -f Dockerfile.gpu .
+
+# Requires the NVIDIA Container Toolkit
+docker run --rm -it \
+  --gpus all \
+  -p 8888:8888 \
+  -v $(pwd):/app \
+  parallel-programming:gpu
+```
+
+> Both images include common image dependencies (`ffmpeg`, `libsm6`, `libxext6`, `libgl1`, `libglib2.0-0`) to support torchvision and Pillow-based pipelines.
+
+#### Docker Compose (CPU or GPU via profiles)
+
+Profiles let you select the target host without changing commands:
+
+```bash
+# CPU profile
+docker compose --profile cpu up --build
+
+# GPU profile (uses Dockerfile.gpu and requests all visible GPUs)
+docker compose --profile gpu up --build
+```
+
+Containers start in an interactive shell. To launch Jupyter inside an already running container:
+
+```bash
+# In another terminal
+docker compose exec app-cpu jupyter lab --ip 0.0.0.0 --no-browser --port 8888
+# or, for GPU
+docker compose exec app-gpu jupyter lab --ip 0.0.0.0 --no-browser --port 8888
+```
+
+For VS Code Remote Containers, attach to the running service (`app-cpu` or `app-gpu`) to gain a full dev shell.
+
 ---
 
 ## Backends & knobs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: "3.9"
+
+services:
+  app-cpu:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: projectwork:cpu
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - WANDB_MODE=online
+    ports:
+      - "8888:8888"
+    stdin_open: true
+    tty: true
+    profiles: ["cpu"]
+
+  app-gpu:
+    build:
+      context: .
+      dockerfile: Dockerfile.gpu
+    image: projectwork:gpu
+    working_dir: /app
+    volumes:
+      - .:/app
+    environment:
+      - WANDB_MODE=online
+    ports:
+      - "8888:8888"
+    stdin_open: true
+    tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    device_requests:
+      - driver: nvidia
+        count: -1
+        capabilities:
+          - gpu
+    profiles: ["gpu"]


### PR DESCRIPTION
## Summary
- add CPU and GPU Dockerfiles using Python 3.12 with image dependencies and online-only W&B logging
- introduce docker-compose profiles for CPU and GPU hosts to support interactive shells, VS Code, and Jupyter access
- add a project .gitignore and refresh README instructions for the new workflows

## Testing
- Not run (Docker not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922c304f4f08329bf0e66bd45da997e)